### PR TITLE
Add target and rel attributes to WakaTime link in statsBlock

### DIFF
--- a/src/ui/blocks/statsBlock/index.tsx
+++ b/src/ui/blocks/statsBlock/index.tsx
@@ -107,7 +107,10 @@ export default function StatsBlock({
                 <Text>
                     <ul>
                         <li>
-                            <a href='https://wakatime.com/@acwilldev'>
+                            <a
+                                href='https://wakatime.com/@acwilldev'
+                                target='_blank'
+                                rel='noreferrer noopener'>
                                 WakaTime
                             </a>{' '}
                             hours logged: 4,725 hrs 24 mins


### PR DESCRIPTION
This pull request fixes an issue where the WakaTime link in the statsBlock component was missing the target and rel attributes. The commit adds the target="_blank" and rel="noreferrer noopener" attributes to the link, ensuring that it opens in a new tab and follows best practices for security.