### PR TITLE
Add Cards Block and Schema

### DIFF
--- a/plop-templates/block/Block.schema.hbs
+++ b/plop-templates/block/Block.schema.hbs
@@ -1,0 +1,23 @@
+import { defineType, defineField, defineArrayMember } from 'sanity'
+import { FaPlus } from "react-icons/fa";
+
+export const {{camelCase name}}BlockSchema = defineType({
+    type: 'object',
+    name: '{{camelCase name}}Block',
+    icon: FaPlus,
+    fields: [
+        defineField({
+            type: 'string',
+            name: 'example',
+        }),
+    ],
+    preview: {
+        select: {
+            title: 'example',
+        },
+        prepare: ({ title }: { title: string;  }) => ({
+            title: title ?? 'Cards Block',
+            subtitle: `'Cards Block`,
+        }),
+    },
+})

--- a/plop-templates/block/Block.tsx.hbs
+++ b/plop-templates/block/Block.tsx.hbs
@@ -2,9 +2,9 @@ import { cn } from '@/lib/utils'
 
 import Wrap from '@/ui/layout/wrap'
 
-import styles from './{{camelCase name}}.module.scss';
+import styles from './{{camelCase name}}.module.scss'
 
-export default function {{properCase name}}({ wrapIt = true,}:Sanity.{{properCase name}} ) {
+export default function {{properCase name}}({ wrapIt = true}: Sanity.{{camelCase name}}Block ) {
     return (
         <Wrap wrapIt={wrapIt}>
             <div className={cn(styles.{{camelCase name}})}>Welcome, {{name}}!</div>

--- a/plopfile.js
+++ b/plopfile.js
@@ -62,6 +62,11 @@ module.exports = function (plop) {
                 path: 'src/ui/blocks/{{camelCase name}}Block/{{camelCase name}}.test.tsx',
                 templateFile: 'plop-templates/block/Block.test.hbs',
             },
+            {
+                type: 'add',
+                path: 'src/sanity/schemas/blocks/{{dashCase name}}-block-schema.tsx',
+                templateFile: 'plop-templates/block/Block.schema.hbs',
+            },
         ],
     })
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,5 +4,5 @@ export const isDev =
 
 export const apiVersion =
     process.env.NEXT_PUBLIC_SANITY_API_VERSION ?? '2022-03-10'
-export const projectId = process.env.PROJECT_ID ?? '4z3s67le'
-export const dataset = process.env.DATASET ?? 'production'
+export const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ?? '4z3s67le'
+export const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET ?? 'staging'

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,4 +5,4 @@ export const isDev =
 export const apiVersion =
     process.env.NEXT_PUBLIC_SANITY_API_VERSION ?? '2022-03-10'
 export const projectId = process.env.PROJECT_ID ?? '4z3s67le'
-export const dataset = process.env.DATASET ?? 'staging'
+export const dataset = process.env.DATASET ?? 'production'

--- a/src/sanity/schemas/blocks/cards-block-schema.tsx
+++ b/src/sanity/schemas/blocks/cards-block-schema.tsx
@@ -1,0 +1,30 @@
+import { defineType, defineField, defineArrayMember } from 'sanity'
+import { CiGrid42 } from 'react-icons/ci'
+import { blockField } from '../components/block-object'
+import { count } from '@/sanity/utils'
+
+export const cardsBlockSchema = defineType({
+    type: 'object',
+    name: 'cardsBlock',
+    icon: CiGrid42,
+    fields: [
+        ...blockField,
+        defineField({
+            name: 'cards',
+            type: 'array',
+            of: [{ type: 'card' }],
+            title: 'Cards',
+        }),
+    ],
+    preview: {
+        select: {
+            cards: 'cards',
+        },
+        prepare: ({ cards }: { cards: Array<unknown> }) => {
+            return {
+                title: 'Cards Block',
+                subtitle: count(cards),
+            }
+        },
+    },
+})

--- a/src/sanity/schemas/blocks/index.ts
+++ b/src/sanity/schemas/blocks/index.ts
@@ -1,11 +1,12 @@
 export const blocks = [
     { type: 'accordionBlock' },
+    { type: 'cardsBlock' },
+    { type: 'formBlock' },
     { type: 'heroBlock' },
     { type: 'htmlBlock' },
     { type: 'imageBlock' },
-    { type: 'sliderBlock' },
-    { type: 'textBlock' },
-    { type: 'formBlock' },
     { type: 'skillsBlock' },
+    { type: 'sliderBlock' },
     { type: 'statsBlock' },
+    { type: 'textBlock' },
 ]

--- a/src/sanity/schemas/components/card-schema.ts
+++ b/src/sanity/schemas/components/card-schema.ts
@@ -1,0 +1,78 @@
+import { defineType, defineField, defineArrayMember } from 'sanity'
+import { FaAddressCard } from 'react-icons/fa6'
+
+export const cardSchema = defineType({
+    type: 'object',
+    name: 'card',
+    icon: FaAddressCard,
+    fields: [
+        defineField({
+            type: 'string',
+            name: 'projectName',
+            title: 'Project Name',
+        }),
+        defineField({
+            type: 'number',
+            name: 'year',
+        }),
+        defineField({
+            type: 'string',
+            name: 'type',
+            title: 'Type of Work',
+        }),
+        defineField({
+            type: 'string',
+            name: 'siteType',
+        }),
+        defineField({
+            type: 'text',
+            name: 'details',
+        }),
+        defineField({
+            type: 'array',
+            name: 'team',
+            title: 'Team',
+            of: [
+                defineArrayMember({
+                    type: 'string',
+                }),
+            ],
+        }),
+        defineField({
+            type: 'string',
+            name: 'myRole',
+        }),
+        defineField({
+            type: 'string',
+            name: 'techStack',
+        }),
+        defineField({
+            type: 'array',
+            name: 'tech',
+            of: [
+                defineArrayMember({
+                    type: 'string',
+                }),
+            ],
+        }),
+    ],
+    preview: {
+        select: {
+            title: 'projectName',
+            subtitle: 'year',
+            type: 'type',
+        },
+        prepare: ({
+            title,
+            subtitle,
+            type,
+        }: {
+            title: string
+            subtitle: number
+            type: string
+        }) => ({
+            title: title ?? 'Project',
+            subtitle: `${subtitle} - ${type}`,
+        }),
+    },
+})

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -9,6 +9,7 @@ import { pageSchema } from './page/page-schema'
 
 // components
 import { ctaSchema } from './components/cta-schema'
+import { cardSchema } from './components/card-schema'
 import { linkSchema } from './components/link-schema'
 import { imageUrlSchema } from './components/image-url-schema'
 
@@ -25,6 +26,7 @@ import { formTextareaSchema } from './forms/form-textarea-schema'
 
 // blocks
 import { accordionBlockSchema } from './blocks/accordion-block-schema'
+import { cardsBlockSchema } from './blocks/cards-block-schema'
 import { creativeBlockSchema } from './blocks/creative-block-schema'
 import { formBlockSchema } from './blocks/form-block-schema'
 import { heroBlockSchema } from './blocks/hero-block-schema'
@@ -37,6 +39,8 @@ import { textBlockSchema } from './blocks/text-block-schema'
 
 export const schemaTypes = [
     accordionBlockSchema,
+    cardSchema,
+    cardsBlockSchema,
     creativeBlockSchema,
     ctaSchema,
     formBlockSchema,
@@ -59,8 +63,8 @@ export const schemaTypes = [
     navigationSchema,
     pageSchema,
     siteSchema,
-    sliderBlockSchema,
     skillsBlockSchema,
+    sliderBlockSchema,
     statsBlockSchema,
     textBlockSchema,
 ]

--- a/src/types/Sanity.d.ts
+++ b/src/types/Sanity.d.ts
@@ -3,6 +3,12 @@ import type { SanityDocument } from 'next-sanity'
 
 declare global {
     namespace Sanity {
+        type SanityContent = {
+            _type: string
+            style: string
+            children: { _type: string; text: string }[]
+        }[]
+
         // documents
 
         type Site = SanityDocument<{
@@ -69,13 +75,13 @@ declare global {
 
         // blocks
         type accordionBlock = {
-            content: any[]
+            content: SanityContent
             items: { summary: string; details: any[] }[]
             wrapIt?: boolean
         }
 
         type creativeBlock = {
-            content: any[]
+            content: SanityContent
             columns?: [{ percentageWidth?: number; subModules?: Block[] }]
             columnsNumber?: number
             alignItems?: string
@@ -99,7 +105,7 @@ declare global {
         }
 
         type skillsBlock = {
-            content: any[]
+            content: SanityContent
             wrapIt?: boolean
         }
 
@@ -110,9 +116,9 @@ declare global {
         }
 
         type statsBlock = {
-            introContent: any[]
-            githubContent: any[]
-            wakaContent: any[]
+            introContent: SanityContent
+            githubContent: SanityContent
+            wakaContent: SanityContent
             placesWorkedStats: {
                 repositoriesContributedTo: number
                 totalPRContributions: number
@@ -126,6 +132,22 @@ declare global {
             content: any
             images: Image[]
             wrapIt?: boolean
+        }
+
+        type cardsBlock = {
+            content?: SanityContent
+            wrapIt?: boolean
+            cards?: {
+                title: string
+                year: number
+                type: string
+                siteType: string
+                details: string
+                myRole: string
+                techStack: string
+                team: string[]
+                tech: string[]
+            }[]
         }
     }
 }

--- a/src/ui/blocks/cardsBlock/cards.module.scss
+++ b/src/ui/blocks/cardsBlock/cards.module.scss
@@ -1,0 +1,6 @@
+@use '../../styles/settings/' as *;
+@use '../../styles/utils/' as *;
+
+.cards {
+    /* Styles for cards block */
+}

--- a/src/ui/blocks/cardsBlock/cards.module.scss
+++ b/src/ui/blocks/cardsBlock/cards.module.scss
@@ -17,7 +17,7 @@
 }
 
 .scrollItem {
-    min-inline-size: min(304px, 100%);
+    min-inline-size: min(314px, 100%);
     scroll-snap-align: start;
 }
 
@@ -42,6 +42,8 @@
     border-radius: 8px;
     height: 100%;
     margin: 0 auto;
+
+    position: relative;
     z-index: 1;
 }
 

--- a/src/ui/blocks/cardsBlock/cards.module.scss
+++ b/src/ui/blocks/cardsBlock/cards.module.scss
@@ -1,6 +1,84 @@
 @use '../../styles/settings/' as *;
 @use '../../styles/utils/' as *;
 
-.cards {
-    /* Styles for cards block */
+.scroll {
+    display: flex;
+    gap: 20px;
+    margin-inline: -20px;
+    -webkit-overflow-scrolling: touch;
+    overflow-x: auto;
+    overflow-y: visible;
+    overscroll-behavior-inline: contain;
+    padding-block: 40px;
+    padding-inline: 20px;
+    scroll-snap-type: x mandatory;
+    scrollbar-color: var(--accent) var(--white);
+    scrollbar-width: thin;
+}
+
+.scrollItem {
+    min-inline-size: min(304px, 100%);
+    scroll-snap-align: start;
+}
+
+.scroll::-webkit-scrollbar {
+    height: 6px;
+}
+
+.scroll::-webkit-scrollbar-track {
+    background: var(--white);
+    border-radius: 3px;
+    margin-left: 20px;
+    margin-right: 20px;
+}
+
+.scroll::-webkit-scrollbar-thumb {
+    background-color: var(--accent);
+    border-radius: 3px;
+}
+
+.card {
+    background-color: rgb(1, 21, 34);
+    border-radius: 8px;
+    height: 100%;
+    margin: 0 auto;
+    z-index: 1;
+}
+
+.tools {
+    align-items: center;
+    display: flex;
+    padding: 9px;
+}
+
+.circle {
+    padding: 0 4px;
+}
+
+.box {
+    align-items: center;
+    border-radius: 50%;
+    display: inline-block;
+    height: 10px;
+    padding: 1px;
+    width: 10px;
+}
+
+.red {
+    background-color: rgb(255, 96, 92);
+}
+
+.yellow {
+    background-color: rgb(255, 189, 68);
+}
+
+.green {
+    background-color: rgb(0, 202, 78);
+}
+
+.content {
+    color: var(--white);
+    font-family: monospace;
+    padding-bottom: 20px;
+    padding-inline: 20px;
 }

--- a/src/ui/blocks/cardsBlock/cards.stories.tsx
+++ b/src/ui/blocks/cardsBlock/cards.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import Index from './index'
+
+const meta = {
+    title: 'Blocks/CardsBlock',
+    component: Index,
+    tags: ['autodocs'],
+} satisfies Meta<typeof Index>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/ui/blocks/cardsBlock/cards.stories.tsx
+++ b/src/ui/blocks/cardsBlock/cards.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-
+import { h2withParagraph } from '@/lib/content/typicalContent'
 import Index from './index'
 
 const meta = {
@@ -12,4 +12,32 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+    args: {
+        content: h2withParagraph,
+        cards: [
+            {
+                title: 'title',
+                siteType: 'siteType',
+                year: 2022,
+                type: 'type',
+                details: 'details',
+                myRole: 'myRole',
+                techStack: 'techStack',
+                team: ['team'],
+                tech: ['tech'],
+            },
+            {
+                title: 'title',
+                siteType: 'siteType',
+                year: 2022,
+                type: 'type',
+                details: 'details',
+                myRole: 'myRole',
+                techStack: 'techStack',
+                team: ['team'],
+                tech: ['tech'],
+            },
+        ],
+    },
+}

--- a/src/ui/blocks/cardsBlock/cards.test.tsx
+++ b/src/ui/blocks/cardsBlock/cards.test.tsx
@@ -1,9 +1,38 @@
 import '@testing-library/jest-dom'
 import { render } from '@testing-library/react'
 import CardsBlock from './index'
+import { h2withParagraph } from '@/lib/content/typicalContent'
 
 describe('Cards', () => {
     it('renders without crashing', () => {
-        render(<CardsBlock />)
+        render(
+            <CardsBlock
+                content={h2withParagraph}
+                cards={[
+                    {
+                        title: 'title',
+                        siteType: 'siteType',
+                        year: 2022,
+                        type: 'type',
+                        details: 'details',
+                        myRole: 'myRole',
+                        techStack: 'techStack',
+                        team: ['team'],
+                        tech: ['tech'],
+                    },
+                    {
+                        title: 'title',
+                        siteType: 'siteType',
+                        year: 2022,
+                        type: 'type',
+                        details: 'details',
+                        myRole: 'myRole',
+                        techStack: 'techStack',
+                        team: ['team'],
+                        tech: ['tech'],
+                    },
+                ]}
+            />,
+        )
     })
 })

--- a/src/ui/blocks/cardsBlock/cards.test.tsx
+++ b/src/ui/blocks/cardsBlock/cards.test.tsx
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import CardsBlock from './index'
+
+describe('Cards', () => {
+    it('renders without crashing', () => {
+        render(<CardsBlock />)
+    })
+})

--- a/src/ui/blocks/cardsBlock/index.tsx
+++ b/src/ui/blocks/cardsBlock/index.tsx
@@ -12,8 +12,35 @@ export default function Cards({
 }: Sanity.cardsBlock) {
     const [cards, setCards] = useState(initialCards)
 
+    const eggTexts = [
+        '🥚 You found my pointless easter egg! 🥚',
+        "You just can't help yourself, can you?",
+        'Another pointless egg for you! 🥚',
+        "You're really into these eggs, huh? 🥚",
+        'How many more of these will you click? 🥚',
+        'This is the last egg. 🥚',
+        'Ok I lied. 🥚',
+        'This one really is! 🥚',
+        '🥚',
+        '🐣',
+        '🥚',
+        '🐣',
+    ]
+
+    const [eggTextIndex, setEggTextIndex] = useState(0)
+
     const handleRemoveCard = (indexToRemove: number) => {
         setCards(cards?.filter((_, index) => index !== indexToRemove))
+    }
+
+    const changeEggText = () => {
+        if (eggTextIndex === 10) {
+            setEggTextIndex(11)
+        } else if (eggTextIndex === 11) {
+            setEggTextIndex(10)
+        } else {
+            setEggTextIndex((prevIndex) => (prevIndex + 1) % eggTexts.length)
+        }
     }
 
     return (
@@ -136,7 +163,41 @@ export default function Cards({
                         </div>
                     ))}
                     {cards?.length === 0 && (
-                        <Text>Congrats on removing all my work 🥚</Text>
+                        <div className={cn(styles.card)}>
+                            <div className={cn(styles.tools)}>
+                                <button
+                                    className={cn(styles.circle)}
+                                    onClick={changeEggText}>
+                                    <span className='sr-only'>
+                                        red circle/ close button
+                                    </span>
+                                    <span
+                                        className={cn(
+                                            styles.box,
+                                            styles.red,
+                                        )}></span>
+                                </button>
+                                <div className={cn(styles.circle)}>
+                                    <span
+                                        className={cn(
+                                            styles.box,
+                                            styles.yellow,
+                                        )}></span>
+                                </div>
+                                <div className={cn(styles.circle)}>
+                                    <span
+                                        className={cn(
+                                            styles.box,
+                                            styles.green,
+                                        )}></span>
+                                </div>
+                            </div>
+                            <div className={cn(styles.content)}>
+                                <Text className={cn('text-center')}>
+                                    <h3>{eggTexts[eggTextIndex]}</h3>
+                                </Text>
+                            </div>
+                        </div>
                     )}
                 </div>
             </div>

--- a/src/ui/blocks/cardsBlock/index.tsx
+++ b/src/ui/blocks/cardsBlock/index.tsx
@@ -1,15 +1,20 @@
+'use client'
+import { useState } from 'react'
 import { cn } from '@/lib/utils'
-
 import Wrap from '@/ui/layout/wrap'
 import Text from '@/ui/components/text'
 import styles from './cards.module.scss'
 
 export default function Cards({
     content,
-    cards,
+    cards: initialCards,
     wrapIt = true,
 }: Sanity.cardsBlock) {
-    console.log(cards)
+    const [cards, setCards] = useState(initialCards)
+
+    const handleRemoveCard = (indexToRemove: number) => {
+        setCards(cards?.filter((_, index) => index !== indexToRemove))
+    }
 
     return (
         <Wrap wrapIt={wrapIt}>
@@ -20,18 +25,23 @@ export default function Cards({
                 />
                 <div className={cn(styles.scroll)}>
                     {cards?.map((card, key) => (
-                        <div className={cn(styles.scrollItem)}>
-                            <div
-                                className={cn(styles.card)}
-                                key={key}>
+                        <div
+                            className={cn(styles.scrollItem)}
+                            key={key}>
+                            <div className={cn(styles.card)}>
                                 <div className={cn(styles.tools)}>
-                                    <div className={cn(styles.circle)}>
+                                    <button
+                                        className={cn(styles.circle)}
+                                        onClick={() => handleRemoveCard(key)}>
+                                        <span className='sr-only'>
+                                            red circle/ close button
+                                        </span>
                                         <span
                                             className={cn(
                                                 styles.box,
                                                 styles.red,
                                             )}></span>
-                                    </div>
+                                    </button>
                                     <div className={cn(styles.circle)}>
                                         <span
                                             className={cn(
@@ -49,18 +59,85 @@ export default function Cards({
                                 </div>
                                 <div className={cn(styles.content)}>
                                     <Text>
-                                        {card.type}
-                                        {card.siteType}
-                                        {card.details}
-                                        {card.myRole}
-                                        {card.techStack}
-                                        {card.team}
+                                        <span className='absolute top-3 right-3 text-xs'>
+                                            $ {card.type} Work
+                                        </span>
+
+                                        <dl className='flex gap-1 flex-col'>
+                                            <dt className='text-green-400'>
+                                                Site type:
+                                            </dt>
+                                            <dd className='mb-4'>
+                                                {card.siteType}
+                                            </dd>
+
+                                            <dt className='text-green-400'>
+                                                Description:
+                                            </dt>
+                                            <dd className='mb-4'>
+                                                {card.details}
+                                            </dd>
+                                            <dt className='text-green-400'>
+                                                Tech Stack:
+                                            </dt>
+                                            <dd className='mb-4'>
+                                                <span className='text-green-400'>
+                                                    [{' '}
+                                                </span>
+                                                {card.tech.map(
+                                                    (tech, techKey) => (
+                                                        <span key={techKey}>
+                                                            {tech}
+                                                            {techKey !==
+                                                                card.tech
+                                                                    .length -
+                                                                    1 && (
+                                                                <span className='text-green-400'>
+                                                                    {' '}
+                                                                    |{' '}
+                                                                </span>
+                                                            )}
+                                                        </span>
+                                                    ),
+                                                )}
+                                                <span className='text-green-400'>
+                                                    {' '}
+                                                    ]
+                                                </span>
+                                            </dd>
+                                            <dt className='text-green-400'>
+                                                My role:
+                                            </dt>
+                                            <dd className='mb-4'>
+                                                {card.myRole}
+                                            </dd>
+
+                                            <dt className='text-green-400 grow-1'>
+                                                Team:
+                                            </dt>
+                                            <dd>
+                                                <ul className='text-sm list-none'>
+                                                    {card.team.map(
+                                                        (member, memberKey) => (
+                                                            <li key={memberKey}>
+                                                                {member}{' '}
+                                                                <span className='text-green-400'>
+                                                                    ✓
+                                                                </span>
+                                                            </li>
+                                                        ),
+                                                    )}
+                                                </ul>
+                                            </dd>
+                                        </dl>
                                     </Text>
-                                    {/* <Text content={card.tech} /> */}
                                 </div>
                             </div>
                         </div>
                     ))}
+                    {cards?.length === 0 && (
+                        <Text>Congrats on removing all my work 🥚</Text>
+                    )}
                 </div>
             </div>
         </Wrap>

--- a/src/ui/blocks/cardsBlock/index.tsx
+++ b/src/ui/blocks/cardsBlock/index.tsx
@@ -1,13 +1,68 @@
 import { cn } from '@/lib/utils'
 
 import Wrap from '@/ui/layout/wrap'
+import Text from '@/ui/components/text'
+import styles from './cards.module.scss'
 
-import styles from './cards.module.scss';
+export default function Cards({
+    content,
+    cards,
+    wrapIt = true,
+}: Sanity.cardsBlock) {
+    console.log(cards)
 
-export default function Cards({ wrapIt = true,}:Sanity.Cards ) {
     return (
         <Wrap wrapIt={wrapIt}>
-            <div className={cn(styles.cards)}>Welcome, cards!</div>
+            <div className={cn(styles.cards)}>
+                <Text
+                    content={content}
+                    className={cn('mb-1')}
+                />
+                <div className={cn(styles.scroll)}>
+                    {cards?.map((card, key) => (
+                        <div className={cn(styles.scrollItem)}>
+                            <div
+                                className={cn(styles.card)}
+                                key={key}>
+                                <div className={cn(styles.tools)}>
+                                    <div className={cn(styles.circle)}>
+                                        <span
+                                            className={cn(
+                                                styles.box,
+                                                styles.red,
+                                            )}></span>
+                                    </div>
+                                    <div className={cn(styles.circle)}>
+                                        <span
+                                            className={cn(
+                                                styles.box,
+                                                styles.yellow,
+                                            )}></span>
+                                    </div>
+                                    <div className={cn(styles.circle)}>
+                                        <span
+                                            className={cn(
+                                                styles.box,
+                                                styles.green,
+                                            )}></span>
+                                    </div>
+                                </div>
+                                <div className={cn(styles.content)}>
+                                    <Text>
+                                        {card.type}
+                                        {card.siteType}
+                                        {card.details}
+                                        {card.myRole}
+                                        {card.techStack}
+                                        {card.team}
+                                    </Text>
+                                    {/* <Text content={card.tech} /> */}
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
         </Wrap>
     )
 }

--- a/src/ui/blocks/cardsBlock/index.tsx
+++ b/src/ui/blocks/cardsBlock/index.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils'
+
+import Wrap from '@/ui/layout/wrap'
+
+import styles from './cards.module.scss';
+
+export default function Cards({ wrapIt = true,}:Sanity.Cards ) {
+    return (
+        <Wrap wrapIt={wrapIt}>
+            <div className={cn(styles.cards)}>Welcome, cards!</div>
+        </Wrap>
+    )
+}

--- a/src/ui/blocks/index.tsx
+++ b/src/ui/blocks/index.tsx
@@ -7,6 +7,7 @@ import SliderBlock from './sliderBlock'
 import SkillsBlock from './skillsBlock'
 import StatsBlock from './statsBlock'
 import TextBlock from './textBlock'
+import CardsBlock from './cardsBlock'
 
 export default function Blocks({ blocks }: { blocks?: Sanity.Block[] }) {
     return (
@@ -32,6 +33,8 @@ export default function Blocks({ blocks }: { blocks?: Sanity.Block[] }) {
                         return <SliderBlock {...block} key={block._key} />
                     case 'textBlock':
                         return <TextBlock {...block} key={block._key} />
+                    case 'cardsBlock':
+                        return <CardsBlock {...block} key={block._key} />
 
                     default:
                         return <div data-type={block._type} key={block._key} />

--- a/src/ui/components/text/text.module.scss
+++ b/src/ui/components/text/text.module.scss
@@ -29,14 +29,14 @@
             }
         }
     }
-    p {
+    p:not([class]) {
         font-size: 1.1rem;
         &:not(:last-child) {
             margin-bottom: var(--spacing);
         }
     }
-    ul,
-    ol {
+    ul:not([class]),
+    ol:not([class]) {
         font-size: 1.1rem;
         list-style-position: inside;
         list-style-type: disc;
@@ -49,7 +49,7 @@
             }
         }
     }
-    ol {
+    ol:not([class]) {
         list-style-type: decimal;
     }
 


### PR DESCRIPTION
This pull request adds a new "Cards Block" component and its corresponding schema. The "Cards Block" component is used to display a collection of cards with project information. The schema defines the fields for each card, including project name, year, type of work, site type, details, team, my role, tech stack, and tech. This new component and schema will allow for the creation of dynamic and customizable cards within the application.